### PR TITLE
Fix missing classes

### DIFF
--- a/src/CurrencyMismatchException.php
+++ b/src/CurrencyMismatchException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CommerceGuys\Pricing;
+
+/**
+ * This exception is thrown when attempting to perform math using two different currencies.
+ * For example, adding a price in USD to another in EUR.
+ */
+class CurrencyMismatchException extends \RuntimeException implements Exception
+{
+
+}

--- a/src/Price.php
+++ b/src/Price.php
@@ -16,7 +16,7 @@ class Price implements PriceInterface
     /**
      * The price currency.
      *
-     * @var \CommerceGuys\Pricing\CurrencyInterface
+     * @var \CommerceGuys\Intl\Currency\CurrencyInterface
      */
     protected $currency;
 
@@ -206,7 +206,7 @@ class Price implements PriceInterface
      * Used in calculation methods to store the result in a new instance.
      *
      * @param string $amount
-     * @param \CommerceGuys\Pricing\CurrencyInterface $currency
+     * @param \CommerceGuys\Intl\Currency\CurrencyInterface $currency
      *
      * @return \CommerceGuys\Pricing\Price The new Price instance.
      */

--- a/src/PriceInterface.php
+++ b/src/PriceInterface.php
@@ -16,14 +16,14 @@ interface PriceInterface
     /**
      * Returns the price currency.
      *
-     * @return \CommerceGuys\Pricing\Currency
+     * @return \CommerceGuys\Intl\Currency\CurrencyInterface
      */
     public function getCurrency();
 
     /**
      * Converts the Price into the given currency using the given exchange rate.
      *
-     * @param \CommerceGuys\Pricing\CurrencyInterface $currnecy
+     * @param \CommerceGuys\Intl\Currency\CurrencyInterface $currnecy
      * @param string $rate
      *
      * @return \CommerceGuys\Pricing\Price


### PR DESCRIPTION
This fixes broken references to two different classes:

- `CurrencyInterface` which actually exists in the Intl module (not in this one).
- `CurrencyMismatchException` which doesn't seem to exist anywhere.