### PR TITLE
Non-static rounder objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
     "require": {
         "commerceguys/intl": "~0.5"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0"
+    },
     "autoload": {
         "psr-4": {
             "CommerceGuys\\Pricing\\": "src"

--- a/src/Price.php
+++ b/src/Price.php
@@ -3,6 +3,8 @@
 namespace CommerceGuys\Pricing;
 
 use CommerceGuys\Intl\Currency\CurrencyInterface;
+use CommerceGuys\Pricing\Rounding\HalfUpRounder;
+use CommerceGuys\Pricing\Rounding\RounderInterface;
 
 class Price implements PriceInterface
 {
@@ -114,6 +116,24 @@ class Price implements PriceInterface
         $value = bcdiv($this->amount, $divisor, 6);
 
         return $this->newPrice($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function round(RounderInterface $rounder = null, $precision = null)
+    {
+        if ($rounder === null) {
+            $rounder = new HalfUpRounder();
+        }
+
+        if ($precision === null) {
+            $precision = $this->currency->getFractionDigits();
+        }
+
+        $newAmount = $rounder->round($this->amount, $precision);
+
+        return $this->newPrice($newAmount);
     }
 
     /**

--- a/src/PriceInterface.php
+++ b/src/PriceInterface.php
@@ -3,6 +3,7 @@
 namespace CommerceGuys\Pricing;
 
 use CommerceGuys\Intl\Currency\CurrencyInterface;
+use CommerceGuys\Pricing\Rounding\RounderInterface;
 
 interface PriceInterface
 {
@@ -77,6 +78,21 @@ interface PriceInterface
      * @throws \CommerceGuys\Pricing\InvalidArgumentException
      */
     public function divide($divisor);
+
+    /**
+     * Returns a new Price representing the value of this Price rounded
+     * using the specified rounder.
+     *
+     * Defaults to the currency precision if not specified.
+     *
+     * @param RounderInterface|null $rounder   Object used to round the amount
+     * @param integer|null          $precision The number of fraction digits to round to
+     *
+     * @return \CommerceGuys\Pricing\Price
+     *
+     * @throws \CommerceGuys\Pricing\InvalidArgumentException
+     */
+    public function round(RounderInterface $rounder = null, $precision = null);
 
     /**
      * Compares this Price to another.

--- a/src/Rounding/AbstractRounder.php
+++ b/src/Rounding/AbstractRounder.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace CommerceGuys\Pricing\Rounding;
+
+use CommerceGuys\Pricing\InvalidArgumentException;
+use CommerceGuys\Pricing\Price;
+use CommerceGuys\Pricing\PriceInterface;
+
+abstract class AbstractRounder
+{
+    /**
+     * @param PriceInterface $price
+     * @param int|null       $precision
+     *
+     * @return Price
+     */
+    public static function round(PriceInterface $price, $precision = null)
+    {
+        $rounder = new static();
+
+        return $rounder->roundPrice($price, $precision);
+    }
+
+    /**
+     * @param PriceInterface $price
+     * @param int|null       $precision
+     *
+     * @return Price
+     */
+    protected function roundPrice(PriceInterface $price, $precision = null)
+    {
+        if (is_null($precision)) {
+            $precision = $price->getCurrency()->getFractionDigits();
+        }
+
+        if ($precision < 0) {
+            throw new InvalidArgumentException('The provided precision should be a positive number');
+        }
+
+        // Ensure that the amount is positive, has a decimal point and the
+        // needed number of digits.
+        $negative = (bccomp('0', $price->getAmount(), 12) == 1);
+        $signMultiplier = $negative ? '-1' : '1';
+        $amount = bcdiv($price->getAmount(), $signMultiplier, $precision + 1);
+        // The digit evaluated for rounding purposes is the one after the
+        // precision digit (amount = 5.956, precision = 2, digit = 6).
+        $amountParts = explode('.', $amount);
+        $digits = str_split($amountParts[1]);
+        $digit = $digits[$precision];
+
+        if ($digit == 0) {
+            // No need to round, just truncate to the needed precision.
+            $amount = bcdiv($amount, $signMultiplier, $precision);
+
+            return new Price($amount, $price->getCurrency());
+        }
+
+        if ($this->shouldRoundUp($digits, $precision)) {
+            // Add the rounding amount if rounding up.
+            // When rounding down it's enough to just do the truncation.
+            $increment = '0.' . str_repeat('0', $precision) . '5';
+            $amount = bcadd($amount, $increment, $precision + 1);
+        }
+
+        // Truncate the amount to the needed precision, ensure the correct sign.
+        $amount = bcdiv($amount, $signMultiplier, $precision);
+
+        return new Price($amount, $price->getCurrency());
+    }
+
+    /**
+     * @param string[] $digits
+     * @param int      $precision
+     *
+     * @return bool
+     */
+    abstract protected function shouldRoundUp($digits, $precision);
+}

--- a/src/Rounding/AbstractRounder.php
+++ b/src/Rounding/AbstractRounder.php
@@ -45,6 +45,7 @@ abstract class AbstractRounder
         // The digit evaluated for rounding purposes is the one after the
         // precision digit (amount = 5.956, precision = 2, digit = 6).
         $amountParts = explode('.', $amount);
+        $lastWholeDigit = substr($amountParts[0], -1);
         $digits = str_split($amountParts[1]);
         $digit = $digits[$precision];
 
@@ -55,7 +56,7 @@ abstract class AbstractRounder
             return new Price($amount, $price->getCurrency());
         }
 
-        if ($this->shouldRoundUp($digits, $precision)) {
+        if ($this->shouldRoundUp($lastWholeDigit, $digits, $precision)) {
             // Add the rounding amount if rounding up.
             // When rounding down it's enough to just do the truncation.
             $increment = '0.' . str_repeat('0', $precision) . '5';
@@ -69,10 +70,11 @@ abstract class AbstractRounder
     }
 
     /**
+     * @param string   $lastWholeDigit
      * @param string[] $digits
      * @param int      $precision
      *
      * @return bool
      */
-    abstract protected function shouldRoundUp($digits, $precision);
+    abstract protected function shouldRoundUp($lastWholeDigit, $digits, $precision);
 }

--- a/src/Rounding/DownRounder.php
+++ b/src/Rounding/DownRounder.php
@@ -5,12 +5,13 @@ namespace CommerceGuys\Pricing\Rounding;
 class DownRounder extends AbstractRounder
 {
     /**
+     * @param string   $lastWholeDigit
      * @param string[] $digits
      * @param int      $precision
      *
      * @return bool
      */
-    protected function shouldRoundUp($digits, $precision)
+    protected function shouldRoundUp($lastWholeDigit, $digits, $precision)
     {
         return false;
     }

--- a/src/Rounding/DownRounder.php
+++ b/src/Rounding/DownRounder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CommerceGuys\Pricing\Rounding;
+
+class DownRounder extends AbstractRounder
+{
+    /**
+     * @param string[] $digits
+     * @param int      $precision
+     *
+     * @return bool
+     */
+    protected function shouldRoundUp($digits, $precision)
+    {
+        return false;
+    }
+}

--- a/src/Rounding/HalfDownRounder.php
+++ b/src/Rounding/HalfDownRounder.php
@@ -5,12 +5,13 @@ namespace CommerceGuys\Pricing\Rounding;
 class HalfDownRounder extends AbstractRounder
 {
     /**
+     * @param string   $lastWholeDigit
      * @param string[] $digits
      * @param int      $precision
      *
      * @return bool
      */
-    protected function shouldRoundUp($digits, $precision)
+    protected function shouldRoundUp($lastWholeDigit, $digits, $precision)
     {
         return $digits[$precision] > 5;
     }

--- a/src/Rounding/HalfDownRounder.php
+++ b/src/Rounding/HalfDownRounder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CommerceGuys\Pricing\Rounding;
+
+class HalfDownRounder extends AbstractRounder
+{
+    /**
+     * @param string[] $digits
+     * @param int      $precision
+     *
+     * @return bool
+     */
+    protected function shouldRoundUp($digits, $precision)
+    {
+        return $digits[$precision] > 5;
+    }
+}

--- a/src/Rounding/HalfEvenRounder.php
+++ b/src/Rounding/HalfEvenRounder.php
@@ -5,14 +5,17 @@ namespace CommerceGuys\Pricing\Rounding;
 class HalfEvenRounder extends AbstractRounder
 {
     /**
+     * @param string   $lastWholeDigit
      * @param string[] $digits
      * @param int      $precision
      *
      * @return bool
      */
-    protected function shouldRoundUp($digits, $precision)
+    protected function shouldRoundUp($lastWholeDigit, $digits, $precision)
     {
-        if ($digits[$precision] == 5) {
+        if ($precision == 0) {
+            return $lastWholeDigit % 2 != 0;
+        } elseif ($digits[$precision] == 5) {
             return $digits[$precision - 1] % 2 != 0;
         } else {
             // Use the ROUND_HALF_UP logic.

--- a/src/Rounding/HalfEvenRounder.php
+++ b/src/Rounding/HalfEvenRounder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CommerceGuys\Pricing\Rounding;
+
+class HalfEvenRounder extends AbstractRounder
+{
+    /**
+     * @param string[] $digits
+     * @param int      $precision
+     *
+     * @return bool
+     */
+    protected function shouldRoundUp($digits, $precision)
+    {
+        if ($digits[$precision] == 5) {
+            return $digits[$precision - 1] % 2 != 0;
+        } else {
+            // Use the ROUND_HALF_UP logic.
+            return $digits[$precision] > 5;
+        }
+    }
+}

--- a/src/Rounding/HalfOddRounder.php
+++ b/src/Rounding/HalfOddRounder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CommerceGuys\Pricing\Rounding;
+
+class HalfOddRounder extends AbstractRounder
+{
+    /**
+     * @param string[] $digits
+     * @param int      $precision
+     *
+     * @return bool
+     */
+    protected function shouldRoundUp($digits, $precision)
+    {
+        if ($digits[$precision] == 5) {
+            return $digits[$precision - 1] % 2 == 0;
+        } else {
+            // Use the ROUND_HALF_UP logic.
+            return $digits[$precision] > 5;
+        }
+    }
+}

--- a/src/Rounding/HalfOddRounder.php
+++ b/src/Rounding/HalfOddRounder.php
@@ -5,14 +5,17 @@ namespace CommerceGuys\Pricing\Rounding;
 class HalfOddRounder extends AbstractRounder
 {
     /**
+     * @param string   $lastWholeDigit
      * @param string[] $digits
      * @param int      $precision
      *
      * @return bool
      */
-    protected function shouldRoundUp($digits, $precision)
+    protected function shouldRoundUp($lastWholeDigit, $digits, $precision)
     {
-        if ($digits[$precision] == 5) {
+        if ($precision == 0) {
+            return $lastWholeDigit % 2 == 0;
+        } elseif ($digits[$precision] == 5) {
             return $digits[$precision - 1] % 2 == 0;
         } else {
             // Use the ROUND_HALF_UP logic.

--- a/src/Rounding/HalfUpRounder.php
+++ b/src/Rounding/HalfUpRounder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CommerceGuys\Pricing\Rounding;
+
+class HalfUpRounder extends AbstractRounder
+{
+    /**
+     * @param string[] $digits
+     * @param int      $precision
+     *
+     * @return bool
+     */
+    protected function shouldRoundUp($digits, $precision)
+    {
+        return $digits[$precision] >= 5;
+    }
+}

--- a/src/Rounding/HalfUpRounder.php
+++ b/src/Rounding/HalfUpRounder.php
@@ -5,12 +5,13 @@ namespace CommerceGuys\Pricing\Rounding;
 class HalfUpRounder extends AbstractRounder
 {
     /**
+     * @param string   $lastWholeDigit
      * @param string[] $digits
      * @param int      $precision
      *
      * @return bool
      */
-    protected function shouldRoundUp($digits, $precision)
+    protected function shouldRoundUp($lastWholeDigit, $digits, $precision)
     {
         return $digits[$precision] >= 5;
     }

--- a/src/Rounding/RounderInterface.php
+++ b/src/Rounding/RounderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace CommerceGuys\Pricing\Rounding;
+
+interface RounderInterface
+{
+    /**
+     * @param string $amount
+     * @param int    $precision
+     *
+     * @return string
+     */
+    public function round($amount, $precision);
+}

--- a/src/Rounding/UpRounder.php
+++ b/src/Rounding/UpRounder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CommerceGuys\Pricing\Rounding;
+
+class UpRounder extends AbstractRounder
+{
+    /**
+     * @param string[] $digits
+     * @param int      $precision
+     *
+     * @return bool
+     */
+    protected function shouldRoundUp($digits, $precision)
+    {
+        return true;
+    }
+}

--- a/src/Rounding/UpRounder.php
+++ b/src/Rounding/UpRounder.php
@@ -5,12 +5,13 @@ namespace CommerceGuys\Pricing\Rounding;
 class UpRounder extends AbstractRounder
 {
     /**
+     * @param string   $lastWholeDigit
      * @param string[] $digits
      * @param int      $precision
      *
      * @return bool
      */
-    protected function shouldRoundUp($digits, $precision)
+    protected function shouldRoundUp($lastWholeDigit, $digits, $precision)
     {
         return true;
     }

--- a/tests/PriceTest.php
+++ b/tests/PriceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace CommerceGuys\Pricing\Tests;
+
+use CommerceGuys\Intl\Currency\CurrencyRepository;
+use CommerceGuys\Pricing\Price;
+use CommerceGuys\Pricing\Rounding\DownRounder;
+use CommerceGuys\Pricing\Rounding\RounderInterface;
+use CommerceGuys\Pricing\Rounding\UpRounder;
+
+class PriceTest extends \PHPUnit_Framework_TestCase
+{
+    protected $usd;
+
+    protected function setUp()
+    {
+        $currencyRepo = new CurrencyRepository();
+        $this->usd = $currencyRepo->get('USD');
+    }
+
+    /**
+     * @param RounderInterface|null $rounder
+     * @param string                $initialAmount
+     * @param int                   $precision
+     * @param string                $expectedAmount
+     *
+     * @dataProvider dataForTestRound
+     */
+    public function testRound(RounderInterface $rounder = null, $initialAmount, $precision, $expectedAmount)
+    {
+        $price = new Price($initialAmount, $this->usd);
+
+        $result = $price->round($rounder, $precision);
+
+        $this->assertSame($this->usd, $result->getCurrency());
+        $this->assertEquals($expectedAmount, $result->getAmount());
+    }
+
+    public function dataForTestRound()
+    {
+        return array(
+            array(null,              '4.555', null, '4.560'),
+            array(null,              '4.555', 0,    '5.000'),
+            array(null,              '4.555', 1,    '4.600'),
+            array(null,              '4.555', 2,    '4.560'),
+            array(null,              '4.555', 3,    '4.555'),
+            array(new UpRounder(),   '4.555', null, '4.560'),
+            array(new UpRounder(),   '4.555', 0,    '5.000'),
+            array(new UpRounder(),   '4.555', 1,    '4.600'),
+            array(new UpRounder(),   '4.555', 2,    '4.560'),
+            array(new UpRounder(),   '4.555', 3,    '4.555'),
+            array(new DownRounder(), '4.555', null, '4.550'),
+            array(new DownRounder(), '4.555', 0,    '4.000'),
+            array(new DownRounder(), '4.555', 1,    '4.500'),
+            array(new DownRounder(), '4.555', 2,    '4.550'),
+            array(new DownRounder(), '4.555', 3,    '4.555'),
+        );
+    }
+}

--- a/tests/Rounding/AbstractRounderTest.php
+++ b/tests/Rounding/AbstractRounderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace CommerceGuys\Pricing\Tests\Rounding;
+
+use CommerceGuys\Intl\Currency\CurrencyInterface;
+use CommerceGuys\Intl\Currency\CurrencyRepository;
+use CommerceGuys\Pricing\Price;
+use CommerceGuys\Pricing\Rounding\AbstractRounder;
+
+abstract class AbstractRounderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CurrencyInterface
+     */
+    protected $currency;
+
+    /**
+     * @var AbstractRounder
+     */
+    protected $rounder;
+
+    protected function setUp()
+    {
+        $currencyRepo = new CurrencyRepository();
+        $this->currency = $currencyRepo->get('EUR');
+
+        $this->rounder = $this->createRounder();
+    }
+
+    /**
+     * @return AbstractRounder
+     */
+    protected abstract function createRounder();
+
+    /**
+     * @return array
+     */
+    public abstract function getTestData();
+
+    /**
+     * @param string $amount
+     * @param int    $precision
+     * @param string $expectedAmount
+     *
+     * @dataProvider getTestData
+     */
+    public function testRound($amount, $precision, $expectedAmount)
+    {
+        $price = $this->createPrice($amount);
+
+        $actual = $this->rounder->round($price, $precision);
+
+        $this->assertEquals($expectedAmount, $actual->getAmount());
+    }
+
+    /**
+     * @param string $amount
+     *
+     * @dataProvider getTestData
+     */
+    public function testRoundWithoutPrecision($amount)
+    {
+        $price = $this->createPrice($amount);
+
+        $expected = $this->rounder->round($price, $price->getCurrency()->getFractionDigits());
+        $actual = $this->rounder->round($price);
+
+        $this->assertEquals($expected->getAmount(), $actual->getAmount());
+    }
+
+    /**
+     * @param string $amount
+     *
+     * @return Price
+     */
+    protected function createPrice($amount)
+    {
+        return new Price($amount, $this->currency);
+    }
+}

--- a/tests/Rounding/AbstractRounderTest.php
+++ b/tests/Rounding/AbstractRounderTest.php
@@ -2,18 +2,10 @@
 
 namespace CommerceGuys\Pricing\Tests\Rounding;
 
-use CommerceGuys\Intl\Currency\CurrencyInterface;
-use CommerceGuys\Intl\Currency\CurrencyRepository;
-use CommerceGuys\Pricing\Price;
 use CommerceGuys\Pricing\Rounding\AbstractRounder;
 
 abstract class AbstractRounderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var CurrencyInterface
-     */
-    protected $currency;
-
     /**
      * @var AbstractRounder
      */
@@ -21,9 +13,6 @@ abstract class AbstractRounderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $currencyRepo = new CurrencyRepository();
-        $this->currency = $currencyRepo->get('EUR');
-
         $this->rounder = $this->createRounder();
     }
 
@@ -46,35 +35,8 @@ abstract class AbstractRounderTest extends \PHPUnit_Framework_TestCase
      */
     public function testRound($amount, $precision, $expectedAmount)
     {
-        $price = $this->createPrice($amount);
+        $actual = $this->rounder->round($amount, $precision);
 
-        $actual = $this->rounder->round($price, $precision);
-
-        $this->assertEquals($expectedAmount, $actual->getAmount());
-    }
-
-    /**
-     * @param string $amount
-     *
-     * @dataProvider getTestData
-     */
-    public function testRoundWithoutPrecision($amount)
-    {
-        $price = $this->createPrice($amount);
-
-        $expected = $this->rounder->round($price, $price->getCurrency()->getFractionDigits());
-        $actual = $this->rounder->round($price);
-
-        $this->assertEquals($expected->getAmount(), $actual->getAmount());
-    }
-
-    /**
-     * @param string $amount
-     *
-     * @return Price
-     */
-    protected function createPrice($amount)
-    {
-        return new Price($amount, $this->currency);
+        $this->assertEquals($expectedAmount, $actual);
     }
 }

--- a/tests/Rounding/DownRounderTest.php
+++ b/tests/Rounding/DownRounderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CommerceGuys\Pricing\Tests\Rounding;
+
+use CommerceGuys\Pricing\Rounding\AbstractRounder;
+use CommerceGuys\Pricing\Rounding\DownRounder;
+
+class DownRounderTest extends AbstractRounderTest
+{
+    /**
+     * @return AbstractRounder
+     */
+    protected function createRounder()
+    {
+        return new DownRounder();
+    }
+
+    /**
+     * @return array
+     */
+    public function getTestData()
+    {
+        return array(
+            array('5.045', 0, '5'),
+            array('5.045', 1, '5.0'),
+            array('5.045', 2, '5.04'),
+            array('5.045', 3, '5.045'),
+            array('5.055', 0, '5'),
+            array('5.055', 1, '5.0'),
+            array('5.055', 2, '5.05'),
+            array('5.055', 3, '5.055'),
+        );
+    }
+}

--- a/tests/Rounding/HalfDownRounderTest.php
+++ b/tests/Rounding/HalfDownRounderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CommerceGuys\Pricing\Tests\Rounding;
+
+use CommerceGuys\Pricing\Rounding\AbstractRounder;
+use CommerceGuys\Pricing\Rounding\HalfDownRounder;
+
+class HalfDownRounderTest extends AbstractRounderTest
+{
+    /**
+     * @return AbstractRounder
+     */
+    protected function createRounder()
+    {
+        return new HalfDownRounder();
+    }
+
+    /**
+     * @return array
+     */
+    public function getTestData()
+    {
+        return array(
+            array('5.050', 0, '5'),
+            array('5.050', 1, '5.0'),
+            array('5.050', 2, '5.05'),
+            array('5.055', 0, '5'),
+            array('5.055', 1, '5.0'),
+            array('5.055', 2, '5.05'),
+            array('5.055', 3, '5.055'),
+        );
+    }
+}

--- a/tests/Rounding/HalfEvenRounderTest.php
+++ b/tests/Rounding/HalfEvenRounderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CommerceGuys\Pricing\Tests\Rounding;
+
+use CommerceGuys\Pricing\Rounding\AbstractRounder;
+use CommerceGuys\Pricing\Rounding\HalfEvenRounder;
+
+class HalfEvenRounderTest extends AbstractRounderTest
+{
+    /**
+     * @return AbstractRounder
+     */
+    protected function createRounder()
+    {
+        return new HalfEvenRounder();
+    }
+
+    /**
+     * @return array
+     */
+    public function getTestData()
+    {
+        return array(
+            array('5.045', 0, '5'),
+            array('5.045', 1, '5.0'),
+            array('5.045', 2, '5.04'),
+            array('5.045', 3, '5.045'),
+            array('5.055', 0, '5'),
+            array('5.055', 1, '5.0'),
+            array('5.055', 2, '5.06'),
+            array('5.055', 3, '5.055'),
+        );
+    }
+}

--- a/tests/Rounding/HalfEvenRounderTest.php
+++ b/tests/Rounding/HalfEvenRounderTest.php
@@ -29,6 +29,7 @@ class HalfEvenRounderTest extends AbstractRounderTest
             array('5.055', 1, '5.0'),
             array('5.055', 2, '5.06'),
             array('5.055', 3, '5.055'),
+            array('5.5',   0, '6'),
         );
     }
 }

--- a/tests/Rounding/HalfOddRounderTest.php
+++ b/tests/Rounding/HalfOddRounderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CommerceGuys\Pricing\Tests\Rounding;
+
+use CommerceGuys\Pricing\Rounding\AbstractRounder;
+use CommerceGuys\Pricing\Rounding\HalfOddRounder;
+
+class HalfOddRounderTest extends AbstractRounderTest
+{
+    /**
+     * @return AbstractRounder
+     */
+    protected function createRounder()
+    {
+        return new HalfOddRounder();
+    }
+
+    /**
+     * @return array
+     */
+    public function getTestData()
+    {
+        return array(
+            array('5.045', 0, '5'),
+            array('5.045', 1, '5.0'),
+            array('5.045', 2, '5.05'),
+            array('5.045', 3, '5.045'),
+            array('5.055', 0, '5'),
+            array('5.055', 1, '5.1'),
+            array('5.055', 2, '5.05'),
+            array('5.055', 3, '5.055'),
+        );
+    }
+}

--- a/tests/Rounding/HalfOddRounderTest.php
+++ b/tests/Rounding/HalfOddRounderTest.php
@@ -29,6 +29,7 @@ class HalfOddRounderTest extends AbstractRounderTest
             array('5.055', 1, '5.1'),
             array('5.055', 2, '5.05'),
             array('5.055', 3, '5.055'),
+            array('5.5',   0, '5'),
         );
     }
 }

--- a/tests/Rounding/HalfUpRounderTest.php
+++ b/tests/Rounding/HalfUpRounderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CommerceGuys\Pricing\Tests\Rounding;
+
+use CommerceGuys\Pricing\Rounding\AbstractRounder;
+use CommerceGuys\Pricing\Rounding\HalfUpRounder;
+
+class HalfUpRounderTest extends AbstractRounderTest
+{
+    /**
+     * @return AbstractRounder
+     */
+    protected function createRounder()
+    {
+        return new HalfUpRounder();
+    }
+
+    /**
+     * @return array
+     */
+    public function getTestData()
+    {
+        return array(
+            array('5.050', 0, '5'),
+            array('5.050', 1, '5.1'),
+            array('5.050', 2, '5.05'),
+            array('5.055', 0, '5'),
+            array('5.055', 1, '5.1'),
+            array('5.055', 2, '5.06'),
+            array('5.055', 3, '5.055'),
+        );
+    }
+}

--- a/tests/Rounding/UpRounderTest.php
+++ b/tests/Rounding/UpRounderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CommerceGuys\Pricing\Tests\Rounding;
+
+use CommerceGuys\Pricing\Rounding\AbstractRounder;
+use CommerceGuys\Pricing\Rounding\UpRounder;
+
+class UpRounderTest extends AbstractRounderTest
+{
+    /**
+     * @return AbstractRounder
+     */
+    protected function createRounder()
+    {
+        return new UpRounder();
+    }
+
+    /**
+     * @return array
+     */
+    public function getTestData()
+    {
+        return array(
+            array('5.045', 0, '5'),
+            array('5.045', 1, '5.0'),
+            array('5.045', 2, '5.05'),
+            array('5.045', 3, '5.045'),
+            array('5.055', 0, '5'),
+            array('5.055', 1, '5.1'),
+            array('5.055', 2, '5.06'),
+            array('5.055', 3, '5.055'),
+        );
+    }
+}


### PR DESCRIPTION
This is similar to #12 (first three commits are identical), except that:
1. Rounder objects are no longer called statically
2. `Price::round()` is re-introduced, but you pass in whichever rounder object you wish to use

Example usage:

``` php
$price = $price->round(new UpRounder(), 1);
```

Both parameters are optional.
- If no rounder is provided, the default round half up method is used.
- If no precision is provided, the currency's fraction digits are used.

(I'm open to renaming the objects to `RoundUp`, `RoundHalfDown`, etc. instead of using `UpRounder`, `HalfDownRounder`, etc.)
