### PR TITLE
Interface should rely on itself, not a concrete implementation

### DIFF
--- a/src/Price.php
+++ b/src/Price.php
@@ -75,7 +75,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function add(Price $other)
+    public function add(PriceInterface $other)
     {
         $this->assertSameCurrency($this, $other);
         $value = bcadd($this->amount, $other->getAmount(), 6);
@@ -86,7 +86,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function subtract(Price $other)
+    public function subtract(PriceInterface $other)
     {
         $this->assertSameCurrency($this, $other);
         $value = bcsub($this->amount, $other->getAmount(), 6);
@@ -119,7 +119,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function compareTo(Price $other)
+    public function compareTo(PriceInterface $other)
     {
         $this->assertSameCurrency($this, $other);
         return bccomp($this->amount, $other->getAmount(), 6);
@@ -128,7 +128,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function equals(Price $other)
+    public function equals(PriceInterface $other)
     {
         return $this->compareTo($other) == 0;
     }
@@ -136,7 +136,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function greaterThan(Price $other)
+    public function greaterThan(PriceInterface $other)
     {
         return $this->compareTo($other) == 1;
     }
@@ -144,7 +144,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function greaterThanOrEqual(Price $other)
+    public function greaterThanOrEqual(PriceInterface $other)
     {
         return $this->greaterThan($other) || $this->equals($other);
     }
@@ -152,7 +152,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function lessThan(Price $other)
+    public function lessThan(PriceInterface $other)
     {
         return $this->compareTo($other) == -1;
     }
@@ -160,7 +160,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function lessThanOrEqual(Price $other)
+    public function lessThanOrEqual(PriceInterface $other)
     {
         return $this->lessThan($other) || $this->equals($other);
     }
@@ -168,12 +168,12 @@ class Price implements PriceInterface
     /**
      * Ensures that the two Price instances have the same currency.
      *
-     * @param \CommerceGuys\Pricing\Price $a
-     * @param \CommerceGuys\Pricing\Price $b
+     * @param PriceInterface $a
+     * @param PriceInterface $b
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    protected function assertSameCurrency(Price $a, Price $b)
+    protected function assertSameCurrency(PriceInterface $a, PriceInterface $b)
     {
         if ($a->getCurrency() != $b->getCurrency()) {
             throw new CurrencyMismatchException;

--- a/src/PriceInterface.php
+++ b/src/PriceInterface.php
@@ -35,24 +35,24 @@ interface PriceInterface
     /**
      * Returns a new Price representing the sum of this Price and another.
      *
-     * @param \CommerceGuys\Pricing\Price $other
+     * @param PriceInterface $other
      *
-     * @return \CommerceGuys\Pricing\Price
+     * @return PriceInterface
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    public function add(Price $other);
+    public function add(PriceInterface $other);
 
     /**
      * Returns a new Price representing the difference of this Price and another.
      *
-     * @param \CommerceGuys\Pricing\Price $other
+     * @param PriceInterface
      *
-     * @return \CommerceGuys\Pricing\Price
+     * @return PriceInterface
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    public function subtract(Price $other);
+    public function subtract(PriceInterface $other);
 
     /**
      * Returns a new Price representing the value of this Price multiplied
@@ -60,7 +60,7 @@ interface PriceInterface
      *
      * @param string $factor
      *
-     * @return \CommerceGuys\Pricing\Price
+     * @return PriceInterface
      *
      * @throws \CommerceGuys\Pricing\InvalidArgumentException
      */
@@ -72,7 +72,7 @@ interface PriceInterface
      *
      * @param string $divisor
      *
-     * @return \CommerceGuys\Pricing\Price
+     * @return PriceInterface
      *
      * @throws \CommerceGuys\Pricing\InvalidArgumentException
      */
@@ -85,66 +85,66 @@ interface PriceInterface
      * if the value of this Price is considered to be respectively
      * less than, equal to, or greater than the other Price.
      *
-     * @param \CommerceGuys\Pricing\Price $other
+     * @param PriceInterface $other
      *
      * @return integer -1|0|1
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    public function compareTo(Price $other);
+    public function compareTo(PriceInterface $other);
 
     /**
      * Returns TRUE if this Price equals another.
      *
-     * @param \CommerceGuys\Pricing\Price $other
+     * @param PriceInterface $other
      *
      * @return boolean
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    public function equals(Price $other);
+    public function equals(PriceInterface $other);
 
     /**
      * Returns TRUE if this Price is greater than another.
      *
-     * @param \CommerceGuys\Pricing\Price $other
+     * @param PriceInterface $other
      *
      * @return boolean
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    public function greaterThan(Price $other);
+    public function greaterThan(PriceInterface $other);
 
     /**
      * Returns TRUE if this Price is greater than or equal to another.
      *
-     * @param \CommerceGuys\Pricing\Price $other
+     * @param PriceInterface $other
      *
      * @return boolean
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    public function greaterThanOrEqual(Price $other);
+    public function greaterThanOrEqual(PriceInterface $other);
 
     /**
      * Returns TRUE if this Price is smaller than another.
      *
-     * @param \CommerceGuys\Pricing\Price $other
+     * @param PriceInterface $other
      *
      * @return boolean
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    public function lessThan(Price $other);
+    public function lessThan(PriceInterface $other);
 
     /**
      * Returns TRUE if this Price is smaller than or equal to another.
      *
-     * @param \CommerceGuys\Pricing\Price $other
+     * @param PriceInterface $other
      *
      * @return boolean
      *
      * @throws \CommerceGuys\Pricing\CurrencyMismatchException
      */
-    public function lessThanOrEqual(Price $other);
+    public function lessThanOrEqual(PriceInterface $other);
 }


### PR DESCRIPTION
Objects implementing the `PriceInterface` can only be added to or subtracted from `Price` objects.  I'd instead expect any `PriceInterface` to be addable to any other `PriceInterface` and not rely on the concrete `Price` implementation.
